### PR TITLE
Improve compliance with guidelines for official images

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,38 +1,38 @@
 FROM debian:buster-slim
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		openssh-client \
-		unzip \
-		dnsutils \
-	; \
-	rm -rf /var/lib/apt/lists/*
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        openssh-client \
+        unzip \
+        dnsutils \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
 # usage: COPY --from=dart:xxx /runtime/ /
 # uses hard links here to save space
 RUN set -eux; \
-	for f in \
-		/etc/nsswitch.conf \
-		/etc/ssl/certs \
-		/lib/x86_64-linux-gnu/libc.so.6 \
-		/lib/x86_64-linux-gnu/libdl.so.2 \
-		/lib/x86_64-linux-gnu/libm.so.6 \
-		/lib/x86_64-linux-gnu/libnss_dns.so.2 \
-		/lib/x86_64-linux-gnu/libpthread.so.0 \
-		/lib/x86_64-linux-gnu/libresolv.so.2 \
-		/lib/x86_64-linux-gnu/librt.so.1 \
-		/lib64/ld-linux-x86-64.so.2 \
-		/usr/share/ca-certificates \
-	; do \
-		dir="$(dirname "$f")"; \
-		mkdir -p "/runtime$dir"; \
-		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
-	done
+    for f in \
+        /etc/nsswitch.conf \
+        /etc/ssl/certs \
+        /lib/x86_64-linux-gnu/libc.so.6 \
+        /lib/x86_64-linux-gnu/libdl.so.2 \
+        /lib/x86_64-linux-gnu/libm.so.6 \
+        /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+        /lib/x86_64-linux-gnu/libpthread.so.0 \
+        /lib/x86_64-linux-gnu/libresolv.so.2 \
+        /lib/x86_64-linux-gnu/librt.so.1 \
+        /lib64/ld-linux-x86-64.so.2 \
+        /usr/share/ca-certificates \
+    ; do \
+        dir="$(dirname "$f")"; \
+        mkdir -p "/runtime$dir"; \
+        cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
+    done
 
 ENV DART_SDK /usr/lib/dart
 ENV PATH $DART_SDK/bin:$PATH

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -1,12 +1,5 @@
 FROM debian:buster-slim
 
-ENV DART_VERSION   {{DART_VERSION}}
-ENV CHANNEL        {{CHANNEL}}
-ENV PLATFORM       {{PLATFORM}}
-ENV ARCH           {{ARCH}}
-
-ENV DART_SDK /usr/lib/dart
-
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -17,18 +10,6 @@ RUN set -eux; \
 		dnsutils \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-WORKDIR /root
-RUN set -eux; \
-    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
-    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
-    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
-    echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";
-
-ENV PATH $DART_SDK/bin:$PATH
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
@@ -52,3 +33,21 @@ RUN set -eux; \
 		mkdir -p "/runtime$dir"; \
 		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
 	done
+
+ENV DART_SDK /usr/lib/dart
+ENV PATH $DART_SDK/bin:$PATH
+
+ENV PLATFORM       {{PLATFORM}}
+ENV ARCH           {{ARCH}}
+ENV CHANNEL        {{CHANNEL}}
+ENV DART_VERSION   {{DART_VERSION}}
+
+WORKDIR /root
+RUN set -eux; \
+    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
+    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
+    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
+    echo "SDK: $URL" >> dart_setup.log ; \
+    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
+    sha256sum --status -c "$SDK".sha256sum; \
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -41,6 +41,7 @@ ENV PLATFORM       {{PLATFORM}}
 ENV ARCH           {{ARCH}}
 ENV CHANNEL        {{CHANNEL}}
 ENV DART_VERSION   {{DART_VERSION}}
+ENV DART_SHA256    {{DART_SHA256}}
 
 WORKDIR /root
 RUN set -eux; \
@@ -48,6 +49,7 @@ RUN set -eux; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
     URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
     echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
+    curl -fLO "$URL"; \
+    echo "$DART_SHA256 *$SDK" \
+    | sha256sum --check --status --strict -; \
     unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";

--- a/beta/buster/Dockerfile
+++ b/beta/buster/Dockerfile
@@ -1,38 +1,38 @@
 FROM debian:buster-slim
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		openssh-client \
-		unzip \
-		dnsutils \
-	; \
-	rm -rf /var/lib/apt/lists/*
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        openssh-client \
+        unzip \
+        dnsutils \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
 # usage: COPY --from=dart:xxx /runtime/ /
 # uses hard links here to save space
 RUN set -eux; \
-	for f in \
-		/etc/nsswitch.conf \
-		/etc/ssl/certs \
-		/lib/x86_64-linux-gnu/libc.so.6 \
-		/lib/x86_64-linux-gnu/libdl.so.2 \
-		/lib/x86_64-linux-gnu/libm.so.6 \
-		/lib/x86_64-linux-gnu/libnss_dns.so.2 \
-		/lib/x86_64-linux-gnu/libpthread.so.0 \
-		/lib/x86_64-linux-gnu/libresolv.so.2 \
-		/lib/x86_64-linux-gnu/librt.so.1 \
-		/lib64/ld-linux-x86-64.so.2 \
-		/usr/share/ca-certificates \
-	; do \
-		dir="$(dirname "$f")"; \
-		mkdir -p "/runtime$dir"; \
-		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
-	done
+    for f in \
+        /etc/nsswitch.conf \
+        /etc/ssl/certs \
+        /lib/x86_64-linux-gnu/libc.so.6 \
+        /lib/x86_64-linux-gnu/libdl.so.2 \
+        /lib/x86_64-linux-gnu/libm.so.6 \
+        /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+        /lib/x86_64-linux-gnu/libpthread.so.0 \
+        /lib/x86_64-linux-gnu/libresolv.so.2 \
+        /lib/x86_64-linux-gnu/librt.so.1 \
+        /lib64/ld-linux-x86-64.so.2 \
+        /usr/share/ca-certificates \
+    ; do \
+        dir="$(dirname "$f")"; \
+        mkdir -p "/runtime$dir"; \
+        cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
+    done
 
 ENV DART_SDK /usr/lib/dart
 ENV PATH $DART_SDK/bin:$PATH

--- a/beta/buster/Dockerfile
+++ b/beta/buster/Dockerfile
@@ -1,12 +1,5 @@
 FROM debian:buster-slim
 
-ENV DART_VERSION   2.13.0-211.6.beta
-ENV CHANNEL        beta
-ENV PLATFORM       linux
-ENV ARCH           x64
-
-ENV DART_SDK /usr/lib/dart
-
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -17,18 +10,6 @@ RUN set -eux; \
 		dnsutils \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-WORKDIR /root
-RUN set -eux; \
-    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
-    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
-    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
-    echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";
-
-ENV PATH $DART_SDK/bin:$PATH
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
@@ -52,3 +33,21 @@ RUN set -eux; \
 		mkdir -p "/runtime$dir"; \
 		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
 	done
+
+ENV DART_SDK /usr/lib/dart
+ENV PATH $DART_SDK/bin:$PATH
+
+ENV PLATFORM       linux
+ENV ARCH           x64
+ENV CHANNEL        beta
+ENV DART_VERSION   2.13.0-211.6.beta
+
+WORKDIR /root
+RUN set -eux; \
+    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
+    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
+    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
+    echo "SDK: $URL" >> dart_setup.log ; \
+    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
+    sha256sum --status -c "$SDK".sha256sum; \
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";

--- a/beta/buster/Dockerfile
+++ b/beta/buster/Dockerfile
@@ -41,6 +41,7 @@ ENV PLATFORM       linux
 ENV ARCH           x64
 ENV CHANNEL        beta
 ENV DART_VERSION   2.13.0-211.6.beta
+ENV DART_SHA256    b91855a45cd101c41728e0e7031e6cd80cc4fd64d30d57df95672c8941f72ffb
 
 WORKDIR /root
 RUN set -eux; \
@@ -48,6 +49,7 @@ RUN set -eux; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
     URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
     echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
+    curl -fLO "$URL"; \
+    echo "$DART_SHA256 *$SDK" \
+    | sha256sum --check --status --strict -; \
     unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -1,12 +1,5 @@
 FROM debian:buster-slim
 
-ENV DART_VERSION   2.12.4
-ENV CHANNEL        stable
-ENV PLATFORM       linux
-ENV ARCH           x64
-
-ENV DART_SDK /usr/lib/dart
-
 RUN set -eux; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
@@ -17,18 +10,6 @@ RUN set -eux; \
 		dnsutils \
 	; \
 	rm -rf /var/lib/apt/lists/*
-
-WORKDIR /root
-RUN set -eux; \
-    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
-    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
-    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
-    echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";
-
-ENV PATH $DART_SDK/bin:$PATH
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
@@ -52,3 +33,21 @@ RUN set -eux; \
 		mkdir -p "/runtime$dir"; \
 		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
 	done
+
+ENV DART_SDK /usr/lib/dart
+ENV PATH $DART_SDK/bin:$PATH
+
+ENV PLATFORM       linux
+ENV ARCH           x64
+ENV CHANNEL        stable
+ENV DART_VERSION   2.12.4
+
+WORKDIR /root
+RUN set -eux; \
+    SDK="dartsdk-$PLATFORM-$ARCH-release.zip"; \
+    BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
+    URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
+    echo "SDK: $URL" >> dart_setup.log ; \
+    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
+    sha256sum --status -c "$SDK".sha256sum; \
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -1,38 +1,38 @@
 FROM debian:buster-slim
 
 RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
-		ca-certificates \
-		curl \
-		openssh-client \
-		unzip \
-		dnsutils \
-	; \
-	rm -rf /var/lib/apt/lists/*
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        openssh-client \
+        unzip \
+        dnsutils \
+    ; \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a minimal runtime environment for executing AOT-compiled Dart code
 # with the smallest possible image size.
 # usage: COPY --from=dart:xxx /runtime/ /
 # uses hard links here to save space
 RUN set -eux; \
-	for f in \
-		/etc/nsswitch.conf \
-		/etc/ssl/certs \
-		/lib/x86_64-linux-gnu/libc.so.6 \
-		/lib/x86_64-linux-gnu/libdl.so.2 \
-		/lib/x86_64-linux-gnu/libm.so.6 \
-		/lib/x86_64-linux-gnu/libnss_dns.so.2 \
-		/lib/x86_64-linux-gnu/libpthread.so.0 \
-		/lib/x86_64-linux-gnu/libresolv.so.2 \
-		/lib/x86_64-linux-gnu/librt.so.1 \
-		/lib64/ld-linux-x86-64.so.2 \
-		/usr/share/ca-certificates \
-	; do \
-		dir="$(dirname "$f")"; \
-		mkdir -p "/runtime$dir"; \
-		cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
-	done
+    for f in \
+        /etc/nsswitch.conf \
+        /etc/ssl/certs \
+        /lib/x86_64-linux-gnu/libc.so.6 \
+        /lib/x86_64-linux-gnu/libdl.so.2 \
+        /lib/x86_64-linux-gnu/libm.so.6 \
+        /lib/x86_64-linux-gnu/libnss_dns.so.2 \
+        /lib/x86_64-linux-gnu/libpthread.so.0 \
+        /lib/x86_64-linux-gnu/libresolv.so.2 \
+        /lib/x86_64-linux-gnu/librt.so.1 \
+        /lib64/ld-linux-x86-64.so.2 \
+        /usr/share/ca-certificates \
+    ; do \
+        dir="$(dirname "$f")"; \
+        mkdir -p "/runtime$dir"; \
+        cp --archive --link --dereference --no-target-directory "$f" "/runtime$f"; \
+    done
 
 ENV DART_SDK /usr/lib/dart
 ENV PATH $DART_SDK/bin:$PATH

--- a/stable/buster/Dockerfile
+++ b/stable/buster/Dockerfile
@@ -41,6 +41,7 @@ ENV PLATFORM       linux
 ENV ARCH           x64
 ENV CHANNEL        stable
 ENV DART_VERSION   2.12.4
+ENV DART_SHA256    479fd97114f8dc2e01a29bcf2c9fb46ff2c137390f6fe9f998a8d979604d33fd
 
 WORKDIR /root
 RUN set -eux; \
@@ -48,6 +49,7 @@ RUN set -eux; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \
     URL="$BASEURL/$CHANNEL/release/$DART_VERSION/sdk/$SDK"; \
     echo "SDK: $URL" >> dart_setup.log ; \
-    curl -fLO "$URL" && curl -fLO "$URL".sha256sum; \
-    sha256sum --status -c "$SDK".sha256sum; \
+    curl -fLO "$URL"; \
+    echo "$DART_SHA256 *$SDK" \
+    | sha256sum --check --status --strict -; \
     unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK";


### PR DESCRIPTION
* Re-order instructions to push frequently changing ones into lower layers (https://github.com/docker-library/official-images#cacheability).
* Hardcode the SHA256 checksum into the Dockerfile (https://github.com/docker-library/official-images#security).
* Use spaces instead of tabs (not a guideline, but aligns the remaining instructions with the first after `RUN`).