### PR TITLE
Fix "stable is ahead of beta"

### DIFF
--- a/scripts/lib/src/library.dart
+++ b/scripts/lib/src/library.dart
@@ -17,8 +17,7 @@ GitCommit: $commit
 ''');
   if (stable.version >= beta.version) {
     // stable is ahead of beta, that means stable _is_ beta.
-    var tags = stable.tags
-        .followedBy(beta.tags.where((tag) => !stable.tags.contains(tag)));
+    var tags = stable.tags.followedBy(['beta-sdk', 'beta']);
     library.write(_imageData(tags, 'stable'));
   } else {
     library.write(_imageData(stable.tags, 'stable'));

--- a/scripts/test/library_test.dart
+++ b/scripts/test/library_test.dart
@@ -56,7 +56,8 @@ Directory: stable/buster
   test('build library: stable is ahead of beta', () {
     var stable =
         DartSdkVersion('stable', Version.parse('2.13.0'), {}, fakeRead);
-    var beta = DartSdkVersion('beta', Version.parse('2.13.0-211.6.beta'), {}, fakeRead);
+    var beta = DartSdkVersion(
+        'beta', Version.parse('2.13.0-211.6.beta'), {}, fakeRead);
     var library = buildLibrary('abcdef', stable, beta);
     var expected = '''
 Maintainers: Alexander Thomas <athom@google.com> (@athomas), Tony Pujals <tonypujals@google.com> (@subfuzion)

--- a/scripts/test/library_test.dart
+++ b/scripts/test/library_test.dart
@@ -53,6 +53,25 @@ Directory: stable/buster
     expect(library, expected);
   });
 
+  test('build library: stable is ahead of beta', () {
+    var stable =
+        DartSdkVersion('stable', Version.parse('2.13.0'), {}, fakeRead);
+    var beta = DartSdkVersion('beta', Version.parse('2.13.0-211.6.beta'), {}, fakeRead);
+    var library = buildLibrary('abcdef', stable, beta);
+    var expected = '''
+Maintainers: Alexander Thomas <athom@google.com> (@athomas), Tony Pujals <tonypujals@google.com> (@subfuzion)
+GitRepo: https://github.com/dart-lang/dart-docker.git
+GitFetch: refs/heads/main
+GitCommit: abcdef
+
+Tags: 2.13.0-sdk, 2.13-sdk, 2-sdk, stable-sdk, sdk, 2.13.0, 2.13, 2, stable, latest, beta-sdk, beta
+Architectures: amd64, arm32v7, arm64v8
+Directory: stable/buster
+''';
+
+    expect(library, expected);
+  });
+
   test('get commit test', () {
     expect(commit, matches(r'^\b[0-9a-f]{5,40}\b$'));
   });


### PR DESCRIPTION
Previously, we assumed that beta would be pushed to stable before updating dart-docker, but that is no longer the case since updating dart-docker is now automated in the release script. We didn't handle the case of beta being a different version that is semantically before stable before.