### PR TITLE
Fix permissions for /usr/lib/dart.

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -73,4 +73,5 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" \
+        && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -73,4 +73,4 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";

--- a/beta/bullseye/Dockerfile
+++ b/beta/bullseye/Dockerfile
@@ -73,4 +73,5 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" \
+        && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";

--- a/beta/bullseye/Dockerfile
+++ b/beta/bullseye/Dockerfile
@@ -73,4 +73,4 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";

--- a/stable/bullseye/Dockerfile
+++ b/stable/bullseye/Dockerfile
@@ -73,4 +73,5 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" \
+        && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";

--- a/stable/bullseye/Dockerfile
+++ b/stable/bullseye/Dockerfile
@@ -73,4 +73,4 @@ RUN set -eux; \
     curl -fLO "$URL"; \
     echo "$DART_SHA256 *$SDK" \
         | sha256sum --check --status --strict -; \
-    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK/bin";
+    unzip "$SDK" && mv dart-sdk "$DART_SDK" && rm "$SDK" && chmod 755 "$DART_SDK" && chmod 755 "$DART_SDK/bin";


### PR DESCRIPTION
This directory is currently inaccessible to non-root users.

This is a smilar fix to #65 which fixed #62, except on the
`/usr/lib/dart` directory instead of `/usr/lib/dart/bin/` directory.

To reproduce the issue:

```
docker run --rm -it dart:stable
root@cafa244bc57c:~# ls -l /usr/lib | grep dart
drwx------ 5 root root 4096 Feb  8 03:23 dart
```