### PR TITLE
Process a sha256sum hash file that ends with newline

### DIFF
--- a/scripts/lib/src/versions.dart
+++ b/scripts/lib/src/versions.dart
@@ -105,7 +105,7 @@ class DartSdkVersion {
       var sha256Url =
           baseUri.resolve('$channel/release/$version/sdk/$sdk.sha256sum');
       var sha256sum = await _read(sha256Url);
-      if (!sha256sum.endsWith(sdk)) {
+      if (!sha256sum.trim().endsWith(sdk)) {
         throw StateError("Expected file name $sdk in sha256sum:\n$sha256sum");
       }
       sha256[arch] = sha256sum.split(' ').first;


### PR DESCRIPTION
The hash files produced by our SDK builders now end with a newline.