### PR TITLE
feat: Add RISC-V64 to Dockerfile template

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -29,6 +29,10 @@ RUN set -eux; \
             TRIPLET="aarch64-linux-gnu" ; \
             FILES="/lib/ld-linux-aarch64.so.1 \
                 /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1" ;; \
+        riscv64) \
+            TRIPLET="riscv64-linux-gnu" ; \
+            FILES="/lib/ld-linux-riscv64-lp64d.so.1 \
+                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" ;; \
         *) \
             echo "Unsupported architecture" ; \
             exit 5;; \
@@ -65,6 +69,9 @@ RUN set -eux; \
         arm64) \
             DART_SHA256={{DART_SHA256_ARM64}}; \
             SDK_ARCH="arm64";; \
+        riscv64) \
+            DART_SHA256={{DART_SHA256_RISCV64}}; \
+            SDK_ARCH="riscv64";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -32,7 +32,8 @@ RUN set -eux; \
         riscv64) \
             TRIPLET="riscv64-linux-gnu" ; \
             FILES="/lib/ld-linux-riscv64-lp64d.so.1 \
-                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" ;; \
+                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1 \
+                /usr/lib/riscv64-linux-gnu/libatomic.so.1" ;; \
         *) \
             echo "Unsupported architecture" ; \
             exit 5;; \


### PR DESCRIPTION
This will help towards #96, though there are a bunch of things that need to be resolved first, so making this a draft for now:

* `debian:bullseye-slim` (Stable) doesn't support RISC-V. There's support in `debian:unstable-slim` (Sid), but that's way off for now as there's not even a release date for the present `testing` build *Bookworm*.
* The scripts and tests need to be updated. I made a start on this, but it looks like everything assumes that architectures are present in stable and beta channels. I can't see a way to introduce a new architecture just in beta (for now).