### PR TITLE
add .pub-cache/bin to PATH

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -51,7 +51,7 @@ RUN set -eux; \
     done
 
 ENV DART_SDK /usr/lib/dart
-ENV PATH $DART_SDK/bin:$PATH
+ENV PATH $DART_SDK/bin:/root/.pub-cache/bin:$PATH
 
 WORKDIR /root
 RUN set -eux; \

--- a/beta/bullseye/Dockerfile
+++ b/beta/bullseye/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
     done
 
 ENV DART_SDK /usr/lib/dart
-ENV PATH $DART_SDK/bin:$PATH
+ENV PATH $DART_SDK/bin:/root/.pub-cache/bin:$PATH
 
 WORKDIR /root
 RUN set -eux; \

--- a/stable/bullseye/Dockerfile
+++ b/stable/bullseye/Dockerfile
@@ -51,7 +51,7 @@ RUN set -eux; \
     done
 
 ENV DART_SDK /usr/lib/dart
-ENV PATH $DART_SDK/bin:$PATH
+ENV PATH $DART_SDK/bin:/root/.pub-cache/bin:$PATH
 
 WORKDIR /root
 RUN set -eux; \


### PR DESCRIPTION
This fixes https://github.com/dart-lang/dart-docker/issues/57

`RUN dart pub global activate <package>`

> Warning: Pub installs executables into $HOME/.pub-cache/bin, which is not on your path.
> You can fix that by adding this to your shell's config file (.bashrc, .bash_profile, etc.):
> 
>   export PATH="$PATH":"$HOME/.pub-cache/bin"

This was once already added in the now archived [dart_docker](https://github.com/dart-archive/dart_docker/blob/master/base/Dockerfile.template#L20) repository.

Let me know if there are reasons/concerns that speak against adding `.pub-cache/bin` to the PATH by default, and if this change requires a test.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
