### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,7 +39,7 @@ jobs:
           sed -i 's/image\=.*/image\=dart/' bashbrew/scripts/github-actions/generate.sh
           strategy="$(bashbrew/scripts/github-actions/generate.sh)"
           jq . <<<"$strategy" # sanity check / debugging aid
-          echo "::set-output name=strategy::$strategy"
+          echo "strategy=$strategy" >> $GITHUB_OUTPUT
   test:
     needs: generate-jobs
     strategy: ${{ fromJson(needs.generate-jobs.outputs.strategy) }}


### PR DESCRIPTION
### Description of your changes

Closes #175

Update `.github/workflows/docker-image.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
echo "::set-output name=strategy::$strategy"
```

**TO-BE**

```yaml
echo "strategy=$strategy" >> $GITHUB_OUTPUT
```