### PR TITLE
ci: Add workflow to check tags on DockerHub

### DIFF
--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -1,9 +1,8 @@
 name: Dart Docker Check Tags on DockerHub
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: 0 0 * * 0
+    - cron: '04 8 * * *' # At 0804 each day
 
 permissions:
   contents: read

--- a/.github/workflows/check-tags.yml
+++ b/.github/workflows/check-tags.yml
@@ -1,0 +1,41 @@
+name: Dart Docker Check Tags on DockerHub
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 0 * * 0
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: "bash -Eeuo pipefail -x {0}"
+
+jobs:
+  check-tags:
+    name: Check Tags
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          sparse-checkout: |
+            versions.json
+          sparse-checkout-cone-mode: false
+      - name: Check Tags on DockerHub
+        run: |
+          channels=( stable beta )
+          for channel in "${channels[@]}"
+          do
+            echo "Testing tags for ${channel} channel"
+            DART_VERSION=$(cat versions.json | jq -r .${channel}.version)
+            echo "Looking for Dart version ${DART_VERSION}"
+            docker buildx imagetools inspect dart:${DART_VERSION} --format \
+              "{{json .Manifest}}" > ${channel}_manifest
+            cat versions.json | jq -r ".${channel}.sha256 | keys | .[]" | \
+              sed s/x64/amd64/ | sort > ${channel}_expected
+            cat ${channel}_manifest | jq -r \
+              '[.manifests[].platform.architecture] | sort | .[]' \
+              > ${channel}_found
+            diff ${channel}_expected ${channel}_found
+          done


### PR DESCRIPTION
Fixes #182 by introducing a workflow that compares the tags expected from `versions.json` to the tags present on DockerHub

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
