### PR TITLE
Add groups to pub ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,7 @@ updates:
       interval: "monthly"
     labels:
       - type-infra
+    groups:
+      pub:
+        patterns:
+          - "*"


### PR DESCRIPTION
Currently I have to land a bunch of PRs in sequence. This hopefully means I can just use a single PR.