### PR TITLE
feat: Add RISCV64 to Dockerfile template

### DIFF
--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -29,6 +29,10 @@ RUN set -eux; \
             TRIPLET="aarch64-linux-gnu" ; \
             FILES="/lib/ld-linux-aarch64.so.1 \
                 /lib/aarch64-linux-gnu/ld-linux-aarch64.so.1" ;; \
+        riscv64) \
+            TRIPLET="riscv64-linux-gnu" ; \
+            FILES="/lib/ld-linux-riscv64-lp64d.so.1 \
+                /lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" ;; \
         *) \
             echo "Unsupported architecture" ; \
             exit 5;; \
@@ -65,6 +69,9 @@ RUN set -eux; \
         arm64) \
             DART_SHA256={{DART_SHA256_ARM64}}; \
             SDK_ARCH="arm64";; \
+        riscv64) \
+            DART_SHA256={{DART_SHA256_RISCV64}}; \
+            SDK_ARCH="riscv64";; \
     esac; \
     SDK="dartsdk-linux-${SDK_ARCH}-release.zip"; \
     BASEURL="https://storage.googleapis.com/dart-archive/channels"; \


### PR DESCRIPTION
Fixes #96 

Now that we're using a Trixie base image there's underlying support for RISCV64.

This PR is based on the [Dockerfile.RV64 for at-buildimage](https://github.com/atsign-company/at_dockerfiles/blob/trunk/at-buildimage/Dockerfile.RV64) that we've been using to create a multi arch build image that includes RISCV64 whilst waiting for Debian support to flow through.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
