### PR TITLE
Don't trigger publishing on self-modification

### DIFF
--- a/.github/workflows/publish-library.yml
+++ b/.github/workflows/publish-library.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/workflows/publish-library.yml'
       - 'beta/**'
       - 'stable/**'
 


### PR DESCRIPTION
I enabled that for testing, but it seems to work now so I'm removing it again so it doesn't trigger on dependabot upgrades and creates meaningless PRs to docker's official images repo.